### PR TITLE
[cmake] add option to include python w/o debug info

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,12 +2,16 @@ cmake_minimum_required(VERSION 3.18)
 
 project(cpplot VERSION 0.1)
 option(CPPLOT_INCLUDE_TESTS "Control whether or not to include the test suite" ON)
+option(CPPLOT_DISABLE_PYTHON_DEBUG_BUILD "If set to true, python is included w/o debug info even for debug builds" OFF)
 
 include(GNUInstallDirs)
 find_package(Python 3.10 REQUIRED COMPONENTS Interpreter Development)
 add_library(cpplot INTERFACE)
 target_compile_features(cpplot INTERFACE cxx_std_23)
 target_link_libraries(cpplot INTERFACE Python::Python)
+if (CPPLOT_DISABLE_PYTHON_DEBUG_BUILD)
+    target_compile_options(cpplot INTERFACE CPPLOT_DISABLE_PYTHON_DEBUG_BUILD)
+endif ()
 target_include_directories(cpplot
     INTERFACE $<BUILD_INTERFACE:${cpplot_SOURCE_DIR}/src>
               $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>

--- a/src/cpplot/cpplot.hpp
+++ b/src/cpplot/cpplot.hpp
@@ -8,7 +8,17 @@
 #include <algorithm>
 #include <set>
 
-#include <Python.h>
+#ifdef CPPLOT_DISABLE_PYTHON_DEBUG_BUILD
+    #ifdef _DEBUG
+        #undef _DEBUG
+        #include <Python.h>
+        #define _DEBUG
+    #else
+        #include <Python.h>
+    #endif
+#else
+    #include <Python.h>
+#endif
 
 
 namespace cpplot {


### PR DESCRIPTION
depending on the platform and installation, the debug symbols may not be available and cause errors at link-time.