### PR TITLE
Feature: example add function

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,3 +1,10 @@
 # SPDX-FileCopyrightText: 2024 Dennis Gläser <dennis.a.glaeser@gmail.com>
 # SPDX-License-Identifier: MIT
+
+function (cpplot_add_example NAME SOURCE)
+    add_executable(${NAME} ${SOURCE})
+    target_link_libraries(${NAME} PRIVATE cpplot::cpplot)
+    add_test(NAME ${NAME} COMMAND ./${NAME})
+endfunction ()
+
 cpplot_add_test(example example.cpp)


### PR DESCRIPTION
If one opts out of the tests but opts into the examples, the test add function is not defined.